### PR TITLE
manifest: use updated svox tag to fix picotts

### DIFF
--- a/default.xml
+++ b/default.xml
@@ -275,7 +275,7 @@
   <project path="external/squashfs-tools" name="platform/external/squashfs-tools" groups="pdk" remote="aosp" />
   <project path="external/srtp" name="platform/external/srtp" groups="pdk" remote="aosp" />
   <project path="external/strace" name="platform/external/strace" groups="pdk" remote="aosp" />
-  <project path="external/svox" name="platform/external/svox" groups="pdk" remote="aosp" />
+  <project path="external/svox" name="platform/external/svox" groups="pdk" remote="aosp" revision="refs/tags/android-n-mr2-preview-2" />
   <project path="external/tagsoup" name="platform/external/tagsoup" groups="pdk" remote="aosp" />
   <project path="external/testng" name="platform/external/testng" groups="pdk" remote="aosp" />
   <project path="external/tcpdump" name="platform/external/tcpdump" groups="pdk" remote="aosp" />


### PR DESCRIPTION
PicoTTS is currently broken in AOSP on 64bit nougat builds.
It was fixed in AOSP master and made it into oreo release, but never
made it into nougat release.
https://android-review.googlesource.com/302872
It is in an updated nougat preview tag though, so we can switch to it.

The svox repo can't be forked due to the following:
https://github.com/github/dmca/blob/master/2014/2014-12-22-Cambridge-Mobile.md

BUGBASH-475

Change-Id: I2ab74ba6428614ef8824f52669c37b52daa59927